### PR TITLE
chore: refactor + add typesafety to libsql client options map

### DIFF
--- a/src/db/index.ts
+++ b/src/db/index.ts
@@ -1,27 +1,24 @@
-import { createClient } from "@libsql/client";
+import { createClient, type Config } from "@libsql/client";
 import { drizzle } from "drizzle-orm/libsql";
 import { config } from "../config";
 import * as schema from "./schema";
 
+const { DATABASE_CONNECTION_TYPE } = config.env;
 
-const options = (() => {
-  switch (config.env.DATABASE_CONNECTION_TYPE) {
-    case 'local' : return { 
-      url: 'file:local.sqlite',
-    }
-    case 'remote' : return {
-      url: config.env.DATABASE_URL,
-      authToken: config.env.DATABASE_AUTH_TOKEN!,
-    }
-    case 'local-replica' : return {
-      url: 'file:local.sqlite',
-      syncUrl: config.env.DATABASE_URL,
-      authToken: config.env.DATABASE_AUTH_TOKEN!,
-    }
-  }
-})()
+const options = {
+  local: { url: "file:local.sqlite" },
+  remote: {
+    url: config.env.DATABASE_URL,
+    authToken: config.env.DATABASE_AUTH_TOKEN!,
+  },
+  "local-replica": {
+    url: "file:local.sqlite",
+    syncUrl: config.env.DATABASE_URL,
+    authToken: config.env.DATABASE_AUTH_TOKEN!,
+  },
+} satisfies Record<typeof DATABASE_CONNECTION_TYPE, Config>;
 
-export const client = createClient(options);
+export const client = createClient(options[DATABASE_CONNECTION_TYPE]);
 
 await client.sync();
 


### PR DESCRIPTION
Moved from https://github.com/ethanniser/beth-b2b-saas/pull/3

I refactored the switch statement into an object map with typesafety added through satisfies. This will now catch errors if new connection types are added to valid env values, but missing from the config map, and also makes sure the returned config is always valid.